### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ RFRotate
 
 Drop in rotations for your iOS project.  Support for blocks.
 
-##Installation
+## Installation
 
 ### Installation with CocoaPods
 
@@ -60,12 +60,12 @@ Hope you enjoy it!
 + (void)rotateWithFlex:(UIView*)view withDuration:(NSTimeInterval)duration andDegrees:(NSInteger)degrees andBlock:(void (^)(void))block andCompletion:(void (^)(void))completion;
 ```
 
-##Screenshots
+## Screenshots
 
 ![Screenshot 1](http://i.imgur.com/f2tVRxx.gif)
 ![Screenshot 2](http://i.imgur.com/Hpgesyf.png)
 
-##License
+## License
 
 The MIT License (MIT)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
